### PR TITLE
Fix HTTPS default port

### DIFF
--- a/src/ch/supsi/omega/openbis/SslCertificateHelper.java
+++ b/src/ch/supsi/omega/openbis/SslCertificateHelper.java
@@ -91,11 +91,11 @@ public class SslCertificateHelper
 		try
 		{
 			URL url = new URL(serviceURL);
-			int port = url.getPort();
-			if (port == -1)
-			{
-				port = 433; // standard port for https
-			}
+                        int port = url.getPort();
+                        if (port == -1)
+                        {
+                                port = 443; // standard port for https
+                        }
 			String hostname = url.getHost();
 			SSLSocketFactory factory = HttpsURLConnection.getDefaultSSLSocketFactory();
 			socket = (SSLSocket) factory.createSocket(hostname, port);


### PR DESCRIPTION
## Summary
- fix incorrect default HTTPS port in `SslCertificateHelper`

## Testing
- `javac src/ch/supsi/omega/openbis/SslCertificateHelper.java` *(fails: package org.apache.commons.io does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684071d32fd08328ac240ab672269c68