### PR TITLE
Add mantra hook example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /target/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# OmegaAlpha
+
+This repository contains the public alpha release of the OMEGA project.  A
+small utility script has been added to demonstrate a simple "mantra" hook.
+
+The `mantra_bank.json` file lists calming messages.  Running
+`scripts/stress_mantra.py` prints the first mantra, mimicking the behavior of a
+hook invoked when stress is detected.

--- a/mantra_bank.json
+++ b/mantra_bank.json
@@ -1,0 +1,10 @@
+{
+  "mantra_bank": [
+    "Hakuna Matata",
+    "\u900d\u9059\u904a",
+    "\u7121\u70ba\u800c\u6cbb"
+  ],
+  "hooks": {
+    "stress_detected": "emit('Hakuna Matata')"
+  }
+}

--- a/scripts/stress_mantra.py
+++ b/scripts/stress_mantra.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Simple stress detection hook.
+
+When stress is detected, the program emits a calming mantra.
+The available mantras are stored in `mantra_bank.json`.
+"""
+import json
+import os
+
+MANTRA_FILE = os.path.join(os.path.dirname(__file__), '..', 'mantra_bank.json')
+
+
+def load_mantras():
+    """Load the mantra bank from the JSON file."""
+    with open(MANTRA_FILE, 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    return data.get("mantra_bank", [])
+
+
+def stress_detected():
+    """Hook called when stress is detected."""
+    mantras = load_mantras()
+    mantra = mantras[0] if mantras else "Hakuna Matata"
+    print(mantra)
+
+
+if __name__ == "__main__":
+    stress_detected()


### PR DESCRIPTION
## Summary
- add simple stress detection example script
- keep mantra data in `mantra_bank.json`
- document usage in README
- ignore Python cache directories

## Testing
- `python3 scripts/stress_mantra.py`
- `ant test` *(fails: command not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845332106a08328862ecf5cdbf0c61e